### PR TITLE
Update for template-haskell-2.9.0.0

### DIFF
--- a/Data/Generics/TH/Instances.hs
+++ b/Data/Generics/TH/Instances.hs
@@ -47,6 +47,9 @@ deriving instance Ord Phases
 deriving instance Ord RuleMatch
 deriving instance Ord FixityDirection
 deriving instance Ord Fixity
+deriving instance Ord Role
+deriving instance Ord AnnTarget
+deriving instance Ord TySynEqn
 
 --------------------------------------------------------------------------------
 -- Quasi instances for monad transformers

--- a/Data/Generics/TH/VarSet.hs
+++ b/Data/Generics/TH/VarSet.hs
@@ -152,8 +152,7 @@ varSet e_1   = (let memoized_2 = \x_3 acc_4 -> accVarRef x_3 ((\_x_5 -> case _x_
                                                                                                                                                arg_202
                                                                                                                                                arg_203 -> memoized_156 arg_199 (memoized_7 arg_200 (memoized_198 arg_201 (memoized_165 arg_202 (memoized_159 arg_203 acc_143))))
                                                                                                        Language.Haskell.TH.Syntax.TySynInstD arg_204
-                                                                                                                                             arg_205
-                                                                                                                                             arg_206 -> memoized_7 arg_204 (memoized_198 arg_205 (memoized_47 arg_206 acc_143))) x_142)
+                                                                                                                                             (TySynEqn arg_205 arg_206) -> memoized_7 arg_204 (memoized_198 arg_205 (memoized_47 arg_206 acc_143))) x_142)
                     memoized_198 = GHC.Base.const GHC.Base.id
                     memoized_192 = GHC.Base.const GHC.Base.id
                     memoized_191 = GHC.Base.const GHC.Base.id

--- a/TYB.cabal
+++ b/TYB.cabal
@@ -1,5 +1,5 @@
 Name:                TYB
-Version:             0.2.3
+Version:             0.2.4
 Synopsis:            Template Your Boilerplate - a Template Haskell version of SYB
 Description:         TYB is a generic-programming system that uses Template
                      Haskell to generate boiler-plate traversals at compile
@@ -19,7 +19,7 @@ Cabal-version:       >=1.8
 Library
   Exposed-modules:     Data.Generics.TH
   Build-depends:         base >= 4 && < 5
-                       , template-haskell >= 2.8
+                       , template-haskell >= 2.9
                        , array >= 0.3
                        , containers >= 0.4
                        , mtl >= 2.0


### PR DESCRIPTION
Hey, I'm trying to get the Habit compiler to build.  It depends on TYB, which I've discovered won't build with newer than template-haskell-2.8.0.0, which is too old for me to easily get on my machine via stack.  I've made some changes to get it to build with template-haskell-2.9.0.0 and bumped the version and template-haskell dependency.

As of template-haskell-2.9.0.0, TySynInstD no longer takes a Name, a list of Type and a Type, and instead takes a Name, and a TynSynEqn, which simply wraps the list of Type and Type the TySynInstD constructor took previously.

http://hackage.haskell.org/package/template-haskell-2.9.0.0/docs/Language-Haskell-TH-Syntax.html#v:TySynInstD

According to the file, during compilation util/makeVarSet.hs is supposed to generate Data/Generics/TH/VarSet.hs, which uses the template haskell TySynInstD constructor.  

As far as I can tell, however, util/makeVarSet.hs isn't getting run when I build with cabal.  Instead, there is a static version of Data/Generics/TH/VarSet.hs in the repository on github.  I don't know whether util/makeVarSet.hs would generate the correct code if it did its thing, and not sure how to make that happen.

So instead, I edited Data/Generics/TH/VarSet.hs and Data/Generics/TH/Instances.hs to get it to build with stack lts-1.0 (ghc 7.8.4, template-haskell-2.9.0.0).  There are plenty of warnings, but it builds.  It's not clear to me whether it works, though :)

Cheers,
Ted
